### PR TITLE
Building and linking only shared library

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: beachmat
-Version: 0.99.13
+Version: 0.99.13-1
 Date: 2017-08-15
 Title: Compiling Bioconductor to Handle Each Matrix Type
 Authors@R: c(person("Aaron", "Lun", role = c("aut", "cre"), email =

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,13 @@
+.onLoad <- function(libname, pkgname)
+{
+  ## make DLL available for Windows; others use static library
+  if ("windows" == .Platform$OS.type) {
+    dll <- file.path(libname, pkgname, "lib", .Platform$r_arch,
+                     "libbeachmat.dll")
+    dyn.load(dll)
+  }
+}
+
 pkgconfig <- function(opt = c("PKG_LIBS", "PKG_CPPFLAGS"))
 {
     path <- Sys.getenv(

--- a/inst/testpkg/DESCRIPTION
+++ b/inst/testpkg/DESCRIPTION
@@ -5,10 +5,11 @@ Title: Test whether we can link to beachmat properly
 Author: Aaron Lun <alun@wehi.edu.au>
 Maintainer: Aaron Lun <alun@wehi.edu.au>
 Depends: R (>= 3.4)
-Imports: Rcpp
-Suggests: testthat, beachmat, Matrix, HDF5Array, DelayedArray
+Imports: Rcpp, beachmat
+Suggests: testthat, Matrix, HDF5Array, DelayedArray
 Description: For testing beachmat compilation settings.
 License: GPL-3
 NeedsCompilation: yes
 SystemRequirements: C++11
 LinkingTo: Rcpp, beachmat, Rhdf5lib
+RoxygenNote: 6.0.1

--- a/inst/testpkg/NAMESPACE
+++ b/inst/testpkg/NAMESPACE
@@ -1,3 +1,5 @@
 useDynLib(beachtest, .registration=TRUE, .fixes="cxx_")
 
 importFrom(Rcpp, sourceCpp)
+
+import(beachmat)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -16,7 +16,7 @@ EXPORT_OBJECTS=any_matrix.o character_matrix.o character_output.o integer_matrix
 # Wait for R to build the shared object, and then pick up the object files.
 
 # this is sufficient to build static library with the suitable version of ar
-libbeachmat.a: $(EXPORT_OBJECTS)
+#libbeachmat.a: $(EXPORT_OBJECTS)
 
 SHLIB_CXXLD=$(shell ${R_HOME}/bin/R CMD config SHLIB_CXXLD)
 LDFLAGS=$(shell ${R_HOME}/bin/R CMD config LDFLAGS)
@@ -29,7 +29,8 @@ libbeachmat.dll: $(SHLIB)
 BEACHMAT_LIBDIR="${R_PACKAGE_DIR}/lib${R_ARCH}"
 BEACHMAT_INCLUDEDIR="${R_PACKAGE_DIR}/include/beachmat"
 
-copying: libbeachmat.dll libbeachmat.a
+#copying: libbeachmat.dll libbeachmat.a
+copying: libbeachmat.dll
 	mkdir -p $(BEACHMAT_LIBDIR) $(BEACHMAT_INCLUDEDIR)
 	cp $(EXPORT_HEADERS) $(BEACHMAT_INCLUDEDIR)
 	mv libbeachmat.* $(BEACHMAT_LIBDIR)

--- a/vignettes/beachmat.Rmd
+++ b/vignettes/beachmat.Rmd
@@ -96,27 +96,28 @@ You need to tell the build system to use C++11, by modifying the `SystemRequirem
 SystemRequirements: C++11
 ```
 
-You also need to ensure that `r CRANpkg("Rcpp")` is initialized when your package is loaded.
-This requires addition of `Rcpp` to the `Imports` field of the `DESCRIPTION` file:
+You also need to ensure that both _beachmat_ and `r CRANpkg("Rcpp")` are initialized when your package is loaded.
+This requires addition of both packages to the `Imports` field of the `DESCRIPTION` file:
 
 ```
-Imports: Rcpp
+Imports: Rcpp, beachmat
 ```
 
-... and a corresponding  `importFrom` specification in the `NAMESPACE` file:
+... and a corresponding `import` or `importFrom` specification in the `NAMESPACE` file:
 
 ```
 importFrom(Rcpp, sourceCpp)
+import(beachmat)
 ```
  
-(The exact function to be imported doesn't matter, as long as the namespace is loaded.
+(For `r CRANpkg("Rcpp")` the exact function to be imported doesn't matter, as long as the namespace is loaded.
 Check out the `r CRANpkg("Rcpp")` documentation for more details.)
 
-`r Biocpkg("HDF5Array")`, `r Biocpkg("DelayedArray")` and  _beachmat_ itself should be added to the `Suggests` field, as the API will perform some calls to R functions in those packages to query certain parameters. 
+`r Biocpkg("HDF5Array")` and `r Biocpkg("DelayedArray")` should be added to the `Suggests` field, as the API will perform some calls to R functions in those packages to query certain parameters. 
 If you intend to accept instances of `r CRANpkg("Matrix")` classes, the package should also be listed in the `Suggests` field, if not already in `Imports` or `Depends`:
 
 ```
-Suggests: beachmat, HDF5Array, DelayedArray, Matrix
+Suggests: HDF5Array, DelayedArray, Matrix
 ```
 
 


### PR DESCRIPTION
Here's a stab at making the shared version of `libbeachmat` available to other packages, with an `.onLoad()` function to expose the library when the package is loaded.

This does require moving `beachmat` to `IMPORTS` from `SUGGESTS` in the `DESCRIPTION`, but I'm not sure if that can be avoided with this approach.

I've only tested it on Windows, but I don't think any of the code modifications should affect other platforms, and both **beachmat** and **beachtest** pass `R CMD check` on 32- & 64-bit arch.

I look forward to finding out what I've forgotten to check! 