### PR TITLE
Add Support for 19 Unary Math Functions

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -61,6 +61,10 @@ apply_delayed_exp <- function(raw_input) {
     .Call('_beachmat_apply_delayed_exp', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_expm1 <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_expm1', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -113,6 +113,10 @@ apply_delayed_tanh <- function(raw_input) {
     .Call('_beachmat_apply_delayed_tanh', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_gamma <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_gamma', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -89,6 +89,10 @@ apply_delayed_atanh <- function(raw_input) {
     .Call('_beachmat_apply_delayed_atanh', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_cos <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_cos', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -49,6 +49,10 @@ apply_delayed_floor <- function(raw_input) {
     .Call('_beachmat_apply_delayed_floor', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_trunc <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_trunc', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_round <- function(raw_input) {
     .Call('_beachmat_apply_delayed_round', PACKAGE = 'beachmat', raw_input)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -41,6 +41,10 @@ apply_delayed_sqrt <- function(raw_input) {
     .Call('_beachmat_apply_delayed_sqrt', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_ceiling <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_ceiling', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_round <- function(raw_input) {
     .Call('_beachmat_apply_delayed_round', PACKAGE = 'beachmat', raw_input)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -105,6 +105,10 @@ apply_delayed_sinh <- function(raw_input) {
     .Call('_beachmat_apply_delayed_sinh', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_tan <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_tan', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -45,6 +45,10 @@ apply_delayed_ceiling <- function(raw_input) {
     .Call('_beachmat_apply_delayed_ceiling', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_floor <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_floor', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_round <- function(raw_input) {
     .Call('_beachmat_apply_delayed_round', PACKAGE = 'beachmat', raw_input)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -101,6 +101,10 @@ apply_delayed_sin <- function(raw_input) {
     .Call('_beachmat_apply_delayed_sin', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_sinh <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_sinh', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -109,6 +109,10 @@ apply_delayed_tan <- function(raw_input) {
     .Call('_beachmat_apply_delayed_tan', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_tanh <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_tanh', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,6 +81,10 @@ apply_delayed_asinh <- function(raw_input) {
     .Call('_beachmat_apply_delayed_asinh', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_atan <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_atan', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -65,6 +65,10 @@ apply_delayed_expm1 <- function(raw_input) {
     .Call('_beachmat_apply_delayed_expm1', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_acos <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_acos', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -93,6 +93,10 @@ apply_delayed_cos <- function(raw_input) {
     .Call('_beachmat_apply_delayed_cos', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_cosh <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_cosh', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -77,6 +77,10 @@ apply_delayed_asin <- function(raw_input) {
     .Call('_beachmat_apply_delayed_asin', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_asinh <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_asinh', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,6 +73,10 @@ apply_delayed_acosh <- function(raw_input) {
     .Call('_beachmat_apply_delayed_acosh', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_asin <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_asin', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -97,6 +97,10 @@ apply_delayed_cosh <- function(raw_input) {
     .Call('_beachmat_apply_delayed_cosh', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_sin <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_sin', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -117,6 +117,10 @@ apply_delayed_gamma <- function(raw_input) {
     .Call('_beachmat_apply_delayed_gamma', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_lgamma <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_lgamma', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -37,6 +37,10 @@ apply_delayed_abs <- function(raw_input) {
     .Call('_beachmat_apply_delayed_abs', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_sign <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_sign', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_sqrt <- function(raw_input) {
     .Call('_beachmat_apply_delayed_sqrt', PACKAGE = 'beachmat', raw_input)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -85,6 +85,10 @@ apply_delayed_atan <- function(raw_input) {
     .Call('_beachmat_apply_delayed_atan', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_atanh <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_atanh', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -69,6 +69,10 @@ apply_delayed_acos <- function(raw_input) {
     .Call('_beachmat_apply_delayed_acos', PACKAGE = 'beachmat', raw_input)
 }
 
+apply_delayed_acosh <- function(raw_input) {
+    .Call('_beachmat_apply_delayed_acosh', PACKAGE = 'beachmat', raw_input)
+}
+
 apply_delayed_subset <- function(raw_input, subset, row) {
     .Call('_beachmat_apply_delayed_subset', PACKAGE = 'beachmat', raw_input, subset, row)
 }

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -207,6 +207,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_asin(seed))
     }
 
+    if (generic == "asinh") {
+        return(apply_delayed_asinh(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -231,6 +231,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_sin(seed))
     }
 
+    if (generic == "sinh") {
+        return(apply_delayed_sinh(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -223,6 +223,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_cos(seed))
     }
 
+    if (generic == "cosh") {
+        return(apply_delayed_cosh(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -167,6 +167,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_abs(seed))
     }
 
+    if (generic == "sign") {
+        return(apply_delayed_sign(seed))
+    }
+
     if (generic == "sqrt") {
         return(apply_delayed_sqrt(seed))
     }

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -187,6 +187,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_exp(seed))
     }
 
+    if (generic == "expm1") {
+        return(apply_delayed_expm1(seed))
+    }
+
     if (generic == "log1p") {
         return(apply_delayed_log1p(seed))
     }

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -195,6 +195,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_log1p(seed))
     }
 
+    if (generic == "acos") {
+        return(apply_delayed_acos(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -211,6 +211,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_asinh(seed))
     }
 
+    if (generic == "atan") {
+        return(apply_delayed_atan(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -235,6 +235,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_sinh(seed))
     }
 
+    if (generic == "tan") {
+        return(apply_delayed_tan(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -227,6 +227,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_cosh(seed))
     }
 
+    if (generic == "sin") {
+        return(apply_delayed_sin(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -243,6 +243,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_tanh(seed))
     }
 
+    if (generic == "gamma") {
+        return(apply_delayed_gamma(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -239,6 +239,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_tan(seed))
     }
 
+    if (generic == "tanh") {
+        return(apply_delayed_tanh(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -175,6 +175,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_ceiling(seed))
     }
 
+    if (generic == "floor") {
+        return(apply_delayed_floor(seed))
+    }
+
     if (generic == "exp") {
         return(apply_delayed_exp(seed))
     }

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -199,6 +199,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_acos(seed))
     }
 
+    if (generic == "acosh") {
+        return(apply_delayed_acosh(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -215,6 +215,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_atan(seed))
     }
 
+    if (generic == "atanh") {
+        return(apply_delayed_atanh(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -219,6 +219,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_atanh(seed))
     }
 
+    if (generic == "cos") {
+        return(apply_delayed_cos(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -171,6 +171,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_sqrt(seed))
     }
 
+    if (generic == "ceiling") {
+        return(apply_delayed_ceiling(seed))
+    }
+
     if (generic == "exp") {
         return(apply_delayed_exp(seed))
     }

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -203,6 +203,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_acosh(seed))
     }
 
+    if (generic == "asin") {
+        return(apply_delayed_asin(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -179,6 +179,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_floor(seed))
     }
 
+    if (generic == "trunc") {
+        return(apply_delayed_trunc(seed))
+    }
+
     if (generic == "exp") {
         return(apply_delayed_exp(seed))
     }

--- a/R/initializeCpp-methods.R
+++ b/R/initializeCpp-methods.R
@@ -247,6 +247,10 @@ setMethod("initializeCpp", "DelayedUnaryIsoOpWithArgs", function(x, ...) {
         return(apply_delayed_gamma(seed))
     }
 
+    if (generic == "lgamma") {
+        return(apply_delayed_lgamma(seed))
+    }
+
     if (generic == "round") {
         if (envir$digits != 0) {
             return("only 'digits = 0' are supported for delayed 'round'")

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -1110,6 +1110,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the logarithm of the gamma of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedLgammaHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::lgamma(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -778,6 +778,57 @@ public:
      */
 };
 
+/**
+ * @brief Take the cos of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedCosHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::cos(buffer[i]);
+        }
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            if (buffer[i]) {
+                buffer[i] = std::cos(buffer[i]);
+            } else {
+                buffer[i] = 1;
+            }
+        }
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -548,6 +548,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the acosh of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAcoshHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::acosh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -59,6 +59,52 @@ public:
 };
 
 /**
+ * @brief Take the signum of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedSignHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = (T(0) < buffer[i]) - (buffer[i] < T(0));
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
  * @brief Take the logarithm of a matrix entry.
  * 
  * @tparam Base_ Numeric type for the log base.

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -1064,6 +1064,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the gamma of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedGammaHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::tgamma(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -210,6 +210,52 @@ public:
 };
 
 /**
+ * @brief Take the floor of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedFloorHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::floor(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
  * @brief Take the logarithm of a matrix entry plus 1.
  *
  * @tparam Base_ Numeric type for the log base.

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -640,6 +640,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the asinh of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAsinhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::asinh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -972,6 +972,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the tangent of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedTanHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::tan(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -502,6 +502,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the acos of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAcosHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::acos(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -503,7 +503,7 @@ public:
 };
 
 /**
- * @brief Take the acos of a matrix entry.
+ * @brief Take the arc cosine of a matrix entry.
  */
 template<typename T = double>
 struct DelayedAcosHelper {
@@ -549,7 +549,7 @@ public:
 };
 
 /**
- * @brief Take the acosh of a matrix entry.
+ * @brief Take the inverse hyperbolic cosine of a matrix entry.
  */
 template<typename T = double>
 struct DelayedAcoshHelper {
@@ -595,7 +595,7 @@ public:
 };
 
 /**
- * @brief Take the asin of a matrix entry.
+ * @brief Take the arc sine of a matrix entry.
  */
 template<typename T = double>
 struct DelayedAsinHelper {
@@ -641,7 +641,7 @@ public:
 };
 
 /**
- * @brief Take the asinh of a matrix entry.
+ * @brief Take the inverse hyperbolic sine of a matrix entry.
  */
 template<typename T = double>
 struct DelayedAsinhHelper {
@@ -687,7 +687,7 @@ public:
 };
 
 /**
- * @brief Take the atan of a matrix entry.
+ * @brief Take the arc tangent of a matrix entry.
  */
 template<typename T = double>
 struct DelayedAtanHelper {
@@ -733,7 +733,7 @@ public:
 };
 
 /**
- * @brief Take the atanh of a matrix entry.
+ * @brief Take the inverse hyperbolic tangent of a matrix entry.
  */
 template<typename T = double>
 struct DelayedAtanhHelper {
@@ -779,7 +779,7 @@ public:
 };
 
 /**
- * @brief Take the cos of a matrix entry.
+ * @brief Take the cosine of a matrix entry.
  */
 template<typename T = double>
 struct DelayedCosHelper {
@@ -830,7 +830,7 @@ public:
 };
 
 /**
- * @brief Take the cosh of a matrix entry.
+ * @brief Take the hyperbolic cosine of a matrix entry.
  */
 template<typename T = double>
 struct DelayedCoshHelper {
@@ -874,6 +874,52 @@ public:
                 buffer[i] = 1;
             }
         }
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
+ * @brief Take the sine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedSinHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::sin(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
     }
     /**
      * @endcond

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -164,6 +164,52 @@ public:
 };
 
 /**
+ * @brief Take the ceiling of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedCeilingHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::ceil(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
  * @brief Take the logarithm of a matrix entry plus 1.
  *
  * @tparam Base_ Numeric type for the log base.

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -456,6 +456,52 @@ public:
      */
 };
 
+/**
+ * @brief Use a matrix entry as an exponent minus 1.
+ */
+template<typename T = double>
+struct DelayedExpm1Helper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::expm1(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -1018,6 +1018,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the hyperbolic tangent of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedTanhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::tanh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -686,6 +686,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the atan of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAtanHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::atan(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -594,6 +594,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the asin of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAsinHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::asin(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -59,7 +59,7 @@ public:
 };
 
 /**
- * @brief Take the signum of a matrix entry.
+ * @brief Take the sign of a matrix entry.
  */
 template<typename T = double>
 struct DelayedSignHelper {
@@ -82,7 +82,7 @@ private:
     template<typename Value_, typename Index_>
     void core (Index_ length, Value_* buffer) const {
         for (Index_ i = 0; i < length; ++i) {
-            buffer[i] = (T(0) < buffer[i]) - (buffer[i] < T(0));
+            buffer[i] = (static_cast<T>(0) < buffer[i]) - (buffer[i] < static_cast<T>(0));
         }
     }
 
@@ -471,11 +471,6 @@ public:
      * @endcond
      */
 
-private:
-    template<typename Value_, typename Index_>
-    void core (Index_ length, Value_* buffer) const {
-    }
-
 public:
     /**
      * @cond
@@ -844,11 +839,6 @@ public:
      * @endcond
      */
 
-private:
-    template<typename Value_, typename Index_>
-    void core (Index_ length, Value_* buffer) const {
-    }
-
 public:
     /**
      * @cond
@@ -894,11 +884,6 @@ public:
     /**
      * @endcond
      */
-
-private:
-    template<typename Value_, typename Index_>
-    void core (Index_ length, Value_* buffer) const {
-    }
 
 public:
     /**

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -732,6 +732,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the atanh of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedAtanhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::atanh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -256,6 +256,52 @@ public:
 };
 
 /**
+ * @brief Take the trunc of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedTruncHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::trunc(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
+/**
  * @brief Take the logarithm of a matrix entry plus 1.
  *
  * @tparam Base_ Numeric type for the log base.

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -926,6 +926,52 @@ public:
      */
 };
 
+/**
+ * @brief Take the hyperbolic sine of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedSinhHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = false;
+
+    static constexpr bool always_sparse = true;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::sinh(buffer[i]);
+        }
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        core(length, buffer);
+    }
+
+    template<bool, typename Value_, typename Index_>
+    void sparse(Index_, Index_ number, Value_* buffer, const Index_*) const {
+        core(number, buffer);
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/inst/include/tatami/isometric/unary/math_helpers.hpp
+++ b/inst/include/tatami/isometric/unary/math_helpers.hpp
@@ -829,6 +829,57 @@ public:
      */
 };
 
+/**
+ * @brief Take the cosh of a matrix entry.
+ */
+template<typename T = double>
+struct DelayedCoshHelper {
+public:
+    /**
+     * @cond
+     */
+    static constexpr bool always_dense = true;
+
+    static constexpr bool always_sparse = false;
+
+    static constexpr bool needs_row = false;
+
+    static constexpr bool needs_column = false;
+    /**
+     * @endcond
+     */
+
+private:
+    template<typename Value_, typename Index_>
+    void core (Index_ length, Value_* buffer) const {
+    }
+
+public:
+    /**
+     * @cond
+     */
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void dense(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            buffer[i] = std::cosh(buffer[i]);
+        }
+    }
+
+    template<bool, typename Value_, typename Index_, typename ExtractType_>
+    void expanded(Index_, ExtractType_, Index_ length, Value_* buffer) const {
+        for (Index_ i = 0; i < length; ++i) {
+            if (buffer[i]) {
+                buffer[i] = std::cosh(buffer[i]);
+            } else {
+                buffer[i] = 1;
+            }
+        }
+    }
+    /**
+     * @endcond
+     */
+};
+
 }
 
 #endif

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -126,6 +126,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_ceiling
+SEXP apply_delayed_ceiling(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_ceiling(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_ceiling(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_round
 SEXP apply_delayed_round(SEXP raw_input);
 RcppExport SEXP _beachmat_apply_delayed_round(SEXP raw_inputSEXP) {
@@ -317,6 +327,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_log1p", (DL_FUNC) &_beachmat_apply_delayed_log1p, 1},
     {"_beachmat_apply_delayed_abs", (DL_FUNC) &_beachmat_apply_delayed_abs, 1},
     {"_beachmat_apply_delayed_sqrt", (DL_FUNC) &_beachmat_apply_delayed_sqrt, 1},
+    {"_beachmat_apply_delayed_ceiling", (DL_FUNC) &_beachmat_apply_delayed_ceiling, 1},
     {"_beachmat_apply_delayed_round", (DL_FUNC) &_beachmat_apply_delayed_round, 1},
     {"_beachmat_apply_delayed_exp", (DL_FUNC) &_beachmat_apply_delayed_exp, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -146,6 +146,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_trunc
+SEXP apply_delayed_trunc(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_trunc(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_trunc(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_round
 SEXP apply_delayed_round(SEXP raw_input);
 RcppExport SEXP _beachmat_apply_delayed_round(SEXP raw_inputSEXP) {
@@ -339,6 +349,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_sqrt", (DL_FUNC) &_beachmat_apply_delayed_sqrt, 1},
     {"_beachmat_apply_delayed_ceiling", (DL_FUNC) &_beachmat_apply_delayed_ceiling, 1},
     {"_beachmat_apply_delayed_floor", (DL_FUNC) &_beachmat_apply_delayed_floor, 1},
+    {"_beachmat_apply_delayed_trunc", (DL_FUNC) &_beachmat_apply_delayed_trunc, 1},
     {"_beachmat_apply_delayed_round", (DL_FUNC) &_beachmat_apply_delayed_round, 1},
     {"_beachmat_apply_delayed_exp", (DL_FUNC) &_beachmat_apply_delayed_exp, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -276,6 +276,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_sinh
+SEXP apply_delayed_sinh(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_sinh(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_sinh(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -462,6 +472,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_cos", (DL_FUNC) &_beachmat_apply_delayed_cos, 1},
     {"_beachmat_apply_delayed_cosh", (DL_FUNC) &_beachmat_apply_delayed_cosh, 1},
     {"_beachmat_apply_delayed_sin", (DL_FUNC) &_beachmat_apply_delayed_sin, 1},
+    {"_beachmat_apply_delayed_sinh", (DL_FUNC) &_beachmat_apply_delayed_sinh, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -286,6 +286,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_tan
+SEXP apply_delayed_tan(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_tan(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_tan(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -473,6 +483,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_cosh", (DL_FUNC) &_beachmat_apply_delayed_cosh, 1},
     {"_beachmat_apply_delayed_sin", (DL_FUNC) &_beachmat_apply_delayed_sin, 1},
     {"_beachmat_apply_delayed_sinh", (DL_FUNC) &_beachmat_apply_delayed_sinh, 1},
+    {"_beachmat_apply_delayed_tan", (DL_FUNC) &_beachmat_apply_delayed_tan, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -296,6 +296,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_tanh
+SEXP apply_delayed_tanh(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_tanh(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_tanh(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -484,6 +494,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_sin", (DL_FUNC) &_beachmat_apply_delayed_sin, 1},
     {"_beachmat_apply_delayed_sinh", (DL_FUNC) &_beachmat_apply_delayed_sinh, 1},
     {"_beachmat_apply_delayed_tan", (DL_FUNC) &_beachmat_apply_delayed_tan, 1},
+    {"_beachmat_apply_delayed_tanh", (DL_FUNC) &_beachmat_apply_delayed_tanh, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -206,6 +206,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_asin
+SEXP apply_delayed_asin(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_asin(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_asin(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -385,6 +395,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_expm1", (DL_FUNC) &_beachmat_apply_delayed_expm1, 1},
     {"_beachmat_apply_delayed_acos", (DL_FUNC) &_beachmat_apply_delayed_acos, 1},
     {"_beachmat_apply_delayed_acosh", (DL_FUNC) &_beachmat_apply_delayed_acosh, 1},
+    {"_beachmat_apply_delayed_asin", (DL_FUNC) &_beachmat_apply_delayed_asin, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -316,6 +316,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_lgamma
+SEXP apply_delayed_lgamma(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_lgamma(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_lgamma(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -506,6 +516,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_tan", (DL_FUNC) &_beachmat_apply_delayed_tan, 1},
     {"_beachmat_apply_delayed_tanh", (DL_FUNC) &_beachmat_apply_delayed_tanh, 1},
     {"_beachmat_apply_delayed_gamma", (DL_FUNC) &_beachmat_apply_delayed_gamma, 1},
+    {"_beachmat_apply_delayed_lgamma", (DL_FUNC) &_beachmat_apply_delayed_lgamma, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -226,6 +226,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_atan
+SEXP apply_delayed_atan(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_atan(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_atan(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -407,6 +417,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_acosh", (DL_FUNC) &_beachmat_apply_delayed_acosh, 1},
     {"_beachmat_apply_delayed_asin", (DL_FUNC) &_beachmat_apply_delayed_asin, 1},
     {"_beachmat_apply_delayed_asinh", (DL_FUNC) &_beachmat_apply_delayed_asinh, 1},
+    {"_beachmat_apply_delayed_atan", (DL_FUNC) &_beachmat_apply_delayed_atan, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -256,6 +256,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_cosh
+SEXP apply_delayed_cosh(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_cosh(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_cosh(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -440,6 +450,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_atan", (DL_FUNC) &_beachmat_apply_delayed_atan, 1},
     {"_beachmat_apply_delayed_atanh", (DL_FUNC) &_beachmat_apply_delayed_atanh, 1},
     {"_beachmat_apply_delayed_cos", (DL_FUNC) &_beachmat_apply_delayed_cos, 1},
+    {"_beachmat_apply_delayed_cosh", (DL_FUNC) &_beachmat_apply_delayed_cosh, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -216,6 +216,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_asinh
+SEXP apply_delayed_asinh(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_asinh(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_asinh(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -396,6 +406,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_acos", (DL_FUNC) &_beachmat_apply_delayed_acos, 1},
     {"_beachmat_apply_delayed_acosh", (DL_FUNC) &_beachmat_apply_delayed_acosh, 1},
     {"_beachmat_apply_delayed_asin", (DL_FUNC) &_beachmat_apply_delayed_asin, 1},
+    {"_beachmat_apply_delayed_asinh", (DL_FUNC) &_beachmat_apply_delayed_asinh, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -176,6 +176,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_expm1
+SEXP apply_delayed_expm1(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_expm1(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_expm1(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -352,6 +362,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_trunc", (DL_FUNC) &_beachmat_apply_delayed_trunc, 1},
     {"_beachmat_apply_delayed_round", (DL_FUNC) &_beachmat_apply_delayed_round, 1},
     {"_beachmat_apply_delayed_exp", (DL_FUNC) &_beachmat_apply_delayed_exp, 1},
+    {"_beachmat_apply_delayed_expm1", (DL_FUNC) &_beachmat_apply_delayed_expm1, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -236,6 +236,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_atanh
+SEXP apply_delayed_atanh(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_atanh(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_atanh(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -418,6 +428,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_asin", (DL_FUNC) &_beachmat_apply_delayed_asin, 1},
     {"_beachmat_apply_delayed_asinh", (DL_FUNC) &_beachmat_apply_delayed_asinh, 1},
     {"_beachmat_apply_delayed_atan", (DL_FUNC) &_beachmat_apply_delayed_atan, 1},
+    {"_beachmat_apply_delayed_atanh", (DL_FUNC) &_beachmat_apply_delayed_atanh, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -136,6 +136,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_floor
+SEXP apply_delayed_floor(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_floor(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_floor(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_round
 SEXP apply_delayed_round(SEXP raw_input);
 RcppExport SEXP _beachmat_apply_delayed_round(SEXP raw_inputSEXP) {
@@ -328,6 +338,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_abs", (DL_FUNC) &_beachmat_apply_delayed_abs, 1},
     {"_beachmat_apply_delayed_sqrt", (DL_FUNC) &_beachmat_apply_delayed_sqrt, 1},
     {"_beachmat_apply_delayed_ceiling", (DL_FUNC) &_beachmat_apply_delayed_ceiling, 1},
+    {"_beachmat_apply_delayed_floor", (DL_FUNC) &_beachmat_apply_delayed_floor, 1},
     {"_beachmat_apply_delayed_round", (DL_FUNC) &_beachmat_apply_delayed_round, 1},
     {"_beachmat_apply_delayed_exp", (DL_FUNC) &_beachmat_apply_delayed_exp, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -306,6 +306,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_gamma
+SEXP apply_delayed_gamma(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_gamma(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_gamma(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -495,6 +505,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_sinh", (DL_FUNC) &_beachmat_apply_delayed_sinh, 1},
     {"_beachmat_apply_delayed_tan", (DL_FUNC) &_beachmat_apply_delayed_tan, 1},
     {"_beachmat_apply_delayed_tanh", (DL_FUNC) &_beachmat_apply_delayed_tanh, 1},
+    {"_beachmat_apply_delayed_gamma", (DL_FUNC) &_beachmat_apply_delayed_gamma, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -196,6 +196,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_acosh
+SEXP apply_delayed_acosh(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_acosh(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_acosh(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -374,6 +384,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_exp", (DL_FUNC) &_beachmat_apply_delayed_exp, 1},
     {"_beachmat_apply_delayed_expm1", (DL_FUNC) &_beachmat_apply_delayed_expm1, 1},
     {"_beachmat_apply_delayed_acos", (DL_FUNC) &_beachmat_apply_delayed_acos, 1},
+    {"_beachmat_apply_delayed_acosh", (DL_FUNC) &_beachmat_apply_delayed_acosh, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -186,6 +186,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_acos
+SEXP apply_delayed_acos(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_acos(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_acos(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -363,6 +373,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_round", (DL_FUNC) &_beachmat_apply_delayed_round, 1},
     {"_beachmat_apply_delayed_exp", (DL_FUNC) &_beachmat_apply_delayed_exp, 1},
     {"_beachmat_apply_delayed_expm1", (DL_FUNC) &_beachmat_apply_delayed_expm1, 1},
+    {"_beachmat_apply_delayed_acos", (DL_FUNC) &_beachmat_apply_delayed_acos, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -266,6 +266,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_sin
+SEXP apply_delayed_sin(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_sin(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_sin(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -451,6 +461,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_atanh", (DL_FUNC) &_beachmat_apply_delayed_atanh, 1},
     {"_beachmat_apply_delayed_cos", (DL_FUNC) &_beachmat_apply_delayed_cos, 1},
     {"_beachmat_apply_delayed_cosh", (DL_FUNC) &_beachmat_apply_delayed_cosh, 1},
+    {"_beachmat_apply_delayed_sin", (DL_FUNC) &_beachmat_apply_delayed_sin, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -246,6 +246,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_cos
+SEXP apply_delayed_cos(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_cos(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_cos(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_subset
 SEXP apply_delayed_subset(SEXP raw_input, Rcpp::IntegerVector subset, bool row);
 RcppExport SEXP _beachmat_apply_delayed_subset(SEXP raw_inputSEXP, SEXP subsetSEXP, SEXP rowSEXP) {
@@ -429,6 +439,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_asinh", (DL_FUNC) &_beachmat_apply_delayed_asinh, 1},
     {"_beachmat_apply_delayed_atan", (DL_FUNC) &_beachmat_apply_delayed_atan, 1},
     {"_beachmat_apply_delayed_atanh", (DL_FUNC) &_beachmat_apply_delayed_atanh, 1},
+    {"_beachmat_apply_delayed_cos", (DL_FUNC) &_beachmat_apply_delayed_cos, 1},
     {"_beachmat_apply_delayed_subset", (DL_FUNC) &_beachmat_apply_delayed_subset, 3},
     {"_beachmat_apply_delayed_transpose", (DL_FUNC) &_beachmat_apply_delayed_transpose, 1},
     {"_beachmat_apply_delayed_bind", (DL_FUNC) &_beachmat_apply_delayed_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -116,6 +116,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// apply_delayed_sign
+SEXP apply_delayed_sign(SEXP raw_input);
+RcppExport SEXP _beachmat_apply_delayed_sign(SEXP raw_inputSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< SEXP >::type raw_input(raw_inputSEXP);
+    rcpp_result_gen = Rcpp::wrap(apply_delayed_sign(raw_input));
+    return rcpp_result_gen;
+END_RCPP
+}
 // apply_delayed_sqrt
 SEXP apply_delayed_sqrt(SEXP raw_input);
 RcppExport SEXP _beachmat_apply_delayed_sqrt(SEXP raw_inputSEXP) {
@@ -496,6 +506,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_beachmat_apply_delayed_log", (DL_FUNC) &_beachmat_apply_delayed_log, 2},
     {"_beachmat_apply_delayed_log1p", (DL_FUNC) &_beachmat_apply_delayed_log1p, 1},
     {"_beachmat_apply_delayed_abs", (DL_FUNC) &_beachmat_apply_delayed_abs, 1},
+    {"_beachmat_apply_delayed_sign", (DL_FUNC) &_beachmat_apply_delayed_sign, 1},
     {"_beachmat_apply_delayed_sqrt", (DL_FUNC) &_beachmat_apply_delayed_sqrt, 1},
     {"_beachmat_apply_delayed_ceiling", (DL_FUNC) &_beachmat_apply_delayed_ceiling, 1},
     {"_beachmat_apply_delayed_floor", (DL_FUNC) &_beachmat_apply_delayed_floor, 1},

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -328,3 +328,12 @@ SEXP apply_delayed_asin(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_asinh(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedAsinhHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -293,3 +293,11 @@ SEXP apply_delayed_exp(SEXP raw_input) {
     return output;
 }
 
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_expm1(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedExpm1Helper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -409,3 +409,12 @@ SEXP apply_delayed_tanh(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_gamma(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedGammaHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -346,3 +346,12 @@ SEXP apply_delayed_atan(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_atanh(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedAtanhHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -373,3 +373,12 @@ SEXP apply_delayed_cosh(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_sin(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedSinHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -364,3 +364,12 @@ SEXP apply_delayed_cos(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_cosh(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedCoshHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -319,3 +319,12 @@ SEXP apply_delayed_acosh(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_asin(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedAsinHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -240,6 +240,15 @@ SEXP apply_delayed_abs(SEXP raw_input) {
 }
 
 //[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_sign(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedSignHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}
+
+//[[Rcpp::export(rng=false)]]
 SEXP apply_delayed_sqrt(SEXP raw_input) {
     Rtatami::BoundNumericPointer input(raw_input);
     auto output = Rtatami::new_BoundNumericMatrix();

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -400,3 +400,12 @@ SEXP apply_delayed_tan(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_tanh(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedTanhHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -355,3 +355,12 @@ SEXP apply_delayed_atanh(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_cos(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedCosHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -301,3 +301,12 @@ SEXP apply_delayed_expm1(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_acos(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedAcosHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -337,3 +337,12 @@ SEXP apply_delayed_asinh(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_atan(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedAtanHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -267,6 +267,15 @@ SEXP apply_delayed_floor(SEXP raw_input) {
 }
 
 //[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_trunc(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedTruncHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}
+
+//[[Rcpp::export(rng=false)]]
 SEXP apply_delayed_round(SEXP raw_input) {
     Rtatami::BoundNumericPointer input(raw_input);
     auto output = Rtatami::new_BoundNumericMatrix();

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -418,3 +418,12 @@ SEXP apply_delayed_gamma(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_lgamma(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedLgammaHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -249,6 +249,15 @@ SEXP apply_delayed_sqrt(SEXP raw_input) {
 }
 
 //[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_ceiling(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedCeilingHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}
+
+//[[Rcpp::export(rng=false)]]
 SEXP apply_delayed_round(SEXP raw_input) {
     Rtatami::BoundNumericPointer input(raw_input);
     auto output = Rtatami::new_BoundNumericMatrix();

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -382,3 +382,12 @@ SEXP apply_delayed_sin(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_sinh(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedSinhHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -258,6 +258,15 @@ SEXP apply_delayed_ceiling(SEXP raw_input) {
 }
 
 //[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_floor(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedFloorHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}
+
+//[[Rcpp::export(rng=false)]]
 SEXP apply_delayed_round(SEXP raw_input) {
     Rtatami::BoundNumericPointer input(raw_input);
     auto output = Rtatami::new_BoundNumericMatrix();

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -310,3 +310,12 @@ SEXP apply_delayed_acos(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_acosh(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedAcoshHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/src/delayed_isometric_unary.cpp
+++ b/src/delayed_isometric_unary.cpp
@@ -391,3 +391,12 @@ SEXP apply_delayed_sinh(SEXP raw_input) {
     output->original = input->original; // copying the reference to propagate GC protection.
     return output;
 }
+
+//[[Rcpp::export(rng=false)]]
+SEXP apply_delayed_tan(SEXP raw_input) {
+    Rtatami::BoundNumericPointer input(raw_input);
+    auto output = Rtatami::new_BoundNumericMatrix();
+    output->ptr = tatami::make_DelayedUnaryIsometricOp(input->ptr, tatami::DelayedTanHelper<>());
+    output->original = input->original; // copying the reference to propagate GC protection.
+    return output;
+}

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -311,6 +311,8 @@ test_that("initialization works correctly with DelayedArray nearest integer oper
 })
 
 test_that("initialization works correctly with DelayedArray trigonometric operations", {
+    x0 <- DelayedArray(x)
+
     set.seed(1000)
     a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
     a0 <- DelayedArray(a)
@@ -322,6 +324,10 @@ test_that("initialization works correctly with DelayedArray trigonometric operat
     z <- acos(a0)
     ptr <- initializeCpp(z)
     am_i_ok(acos(a), ptr, exact=FALSE)
+
+    z <- atan(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(atan(x), ptr, exact=FALSE)
 })
 
 test_that("initialization works correctly with DelayedArray hyperbolic operations", {

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -325,9 +325,15 @@ test_that("initialization works correctly with DelayedArray trigonometric operat
 })
 
 test_that("initialization works correctly with DelayedArray hyperbolic operations", {
+    x0 <- DelayedArray(x)
+
     set.seed(1000)
     a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
     a0 <- DelayedArray(a)
+
+    z <- asinh(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(asinh(x), ptr, exact=FALSE)
 
     # Adding a value to make sure domain >= 1.
     z <- acosh(a0 + 2)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -301,6 +301,11 @@ test_that("initialization works correctly with other DelayedArray unary operatio
     ptr <- initializeCpp(z)
     am_i_ok(sqrt(y), ptr, exact=FALSE)
 
+    x0 <- DelayedArray(x)
+    z <- ceiling(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(ceiling(x), ptr)
+
     z <- exp(z0)
     ptr <- initializeCpp(z)
     am_i_ok(exp(y), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -315,6 +315,10 @@ test_that("initialization works correctly with DelayedArray trigonometric operat
     a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
     a0 <- DelayedArray(a)
 
+    z <- asin(a0)
+    ptr <- initializeCpp(z)
+    am_i_ok(asin(a), ptr, exact=FALSE)
+
     z <- acos(a0)
     ptr <- initializeCpp(z)
     am_i_ok(acos(a), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -388,6 +388,7 @@ test_that("initialization works correctly with DelayedArray gamma operations", {
 })
 
 test_that("initialization works correctly with other DelayedArray unary operations", {
+    x0 <- DelayedArray(x)
     z0 <- DelayedArray(y)
 
     z <- +z0 
@@ -402,8 +403,11 @@ test_that("initialization works correctly with other DelayedArray unary operatio
     ptr <- initializeCpp(z)
     am_i_ok(sqrt(y), ptr, exact=FALSE)
 
-    x0 <- DelayedArray(x)
     z <- abs(x0)
     ptr <- initializeCpp(z)
     am_i_ok(abs(x), ptr)
+
+    z <- sign(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(sign(x), ptr)
 })

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -320,6 +320,10 @@ test_that("initialization works correctly with other DelayedArray unary operatio
     ptr <- initializeCpp(z)
     am_i_ok(exp(y), ptr, exact=FALSE)
 
+    z <- expm1(z0)
+    ptr <- initializeCpp(z)
+    am_i_ok(expm1(y), ptr, exact=FALSE)
+
     x0 <- DelayedArray(x)
     z <- abs(x0)
     ptr <- initializeCpp(z)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -317,6 +317,10 @@ test_that("initialization works correctly with DelayedArray trigonometric operat
     a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
     a0 <- DelayedArray(a)
 
+    z <- cos(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(cos(x), ptr, exact=FALSE)
+
     z <- asin(a0)
     ptr <- initializeCpp(z)
     am_i_ok(asin(a), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -317,6 +317,10 @@ test_that("initialization works correctly with DelayedArray trigonometric operat
     a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
     a0 <- DelayedArray(a)
 
+    z <- sin(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(sin(x), ptr, exact=FALSE)
+
     z <- cos(x0)
     ptr <- initializeCpp(z)
     am_i_ok(cos(x), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -341,6 +341,10 @@ test_that("initialization works correctly with DelayedArray hyperbolic operation
     a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
     a0 <- DelayedArray(a)
 
+    z <- cosh(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(cosh(x), ptr, exact=FALSE)
+
     z <- asinh(x0)
     ptr <- initializeCpp(z)
     am_i_ok(asinh(x), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -375,6 +375,14 @@ test_that("initialization works correctly with DelayedArray hyperbolic operation
     am_i_ok(atanh(a), ptr, exact=FALSE)
 })
 
+test_that("initialization works correctly with DelayedArray gamma operations", {
+    z0 <- DelayedArray(y)
+
+    z <- gamma(z0 + 0.1)
+    ptr <- initializeCpp(z)
+    am_i_ok(gamma(y + 0.1), ptr, exact=FALSE)
+})
+
 test_that("initialization works correctly with other DelayedArray unary operations", {
     z0 <- DelayedArray(y)
 

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -320,6 +320,17 @@ test_that("initialization works correctly with DelayedArray trigonometric operat
     am_i_ok(acos(a), ptr, exact=FALSE)
 })
 
+test_that("initialization works correctly with DelayedArray hyperbolic operations", {
+    set.seed(1000)
+    a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
+    a0 <- DelayedArray(a)
+
+    # Adding a value to make sure domain >= 1.
+    z <- acosh(a0 + 2)
+    ptr <- initializeCpp(z)
+    am_i_ok(acosh(a + 2), ptr, exact=FALSE)
+})
+
 test_that("initialization works correctly with other DelayedArray unary operations", {
     z0 <- DelayedArray(y)
 

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -248,8 +248,16 @@ test_that("initialization works correctly with vector boolean operations", {
     }
 })
 
-test_that("initialization works correctly with DelayedArray log-transforms", {
+test_that("initialization works correctly with DelayedArray exponential and log-transforms", {
     z0 <- DelayedArray(y)
+
+    z <- exp(z0)
+    ptr <- initializeCpp(z)
+    am_i_ok(exp(y), ptr, exact=FALSE)
+
+    z <- expm1(z0)
+    ptr <- initializeCpp(z)
+    am_i_ok(expm1(y), ptr, exact=FALSE)
 
     # Adding a value to make sure it's not log-zero.
     z <- log2(z0 + 2)
@@ -267,6 +275,10 @@ test_that("initialization works correctly with DelayedArray log-transforms", {
     z <- log(z0 + 2, 2.5)
     ptr <- initializeCpp(z)
     am_i_ok(log(y + 2, 2.5), ptr, exact=FALSE)
+
+    z <- log1p(z0)
+    ptr <- initializeCpp(z)
+    am_i_ok(log1p(y), ptr, exact=FALSE)
 })
 
 test_that("initialization works correctly with DelayedArray rounding", {
@@ -282,6 +294,22 @@ test_that("initialization works correctly with DelayedArray rounding", {
     am_i_ok(round(ref, 2), ptr)
 })
 
+test_that("initialization works correctly with DelayedArray nearest integer operations", {
+    x0 <- DelayedArray(x)
+
+    z <- ceiling(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(ceiling(x), ptr)
+
+    z <- floor(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(floor(x), ptr)
+
+    z <- trunc(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(trunc(x), ptr)
+})
+
 test_that("initialization works correctly with other DelayedArray unary operations", {
     z0 <- DelayedArray(y)
 
@@ -293,36 +321,9 @@ test_that("initialization works correctly with other DelayedArray unary operatio
     ptr <- initializeCpp(z)
     am_i_ok(-y, ptr)
 
-    z <- log1p(z0)
-    ptr <- initializeCpp(z)
-    am_i_ok(log1p(y), ptr, exact=FALSE)
-
     z <- sqrt(z0)
     ptr <- initializeCpp(z)
     am_i_ok(sqrt(y), ptr, exact=FALSE)
-
-    x0 <- DelayedArray(x)
-    z <- ceiling(x0)
-    ptr <- initializeCpp(z)
-    am_i_ok(ceiling(x), ptr)
-
-    x0 <- DelayedArray(x)
-    z <- floor(x0)
-    ptr <- initializeCpp(z)
-    am_i_ok(floor(x), ptr)
-
-    x0 <- DelayedArray(x)
-    z <- trunc(x0)
-    ptr <- initializeCpp(z)
-    am_i_ok(trunc(x), ptr)
-
-    z <- exp(z0)
-    ptr <- initializeCpp(z)
-    am_i_ok(exp(y), ptr, exact=FALSE)
-
-    z <- expm1(z0)
-    ptr <- initializeCpp(z)
-    am_i_ok(expm1(y), ptr, exact=FALSE)
 
     x0 <- DelayedArray(x)
     z <- abs(x0)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -325,6 +325,10 @@ test_that("initialization works correctly with DelayedArray trigonometric operat
     ptr <- initializeCpp(z)
     am_i_ok(cos(x), ptr, exact=FALSE)
 
+    z <- tan(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(tan(x), ptr, exact=FALSE)
+
     z <- asin(a0)
     ptr <- initializeCpp(z)
     am_i_ok(asin(a), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -306,6 +306,11 @@ test_that("initialization works correctly with other DelayedArray unary operatio
     ptr <- initializeCpp(z)
     am_i_ok(ceiling(x), ptr)
 
+    x0 <- DelayedArray(x)
+    z <- floor(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(floor(x), ptr)
+
     z <- exp(z0)
     ptr <- initializeCpp(z)
     am_i_ok(exp(y), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -311,6 +311,11 @@ test_that("initialization works correctly with other DelayedArray unary operatio
     ptr <- initializeCpp(z)
     am_i_ok(floor(x), ptr)
 
+    x0 <- DelayedArray(x)
+    z <- trunc(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(trunc(x), ptr)
+
     z <- exp(z0)
     ptr <- initializeCpp(z)
     am_i_ok(exp(y), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -345,6 +345,10 @@ test_that("initialization works correctly with DelayedArray hyperbolic operation
     a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
     a0 <- DelayedArray(a)
 
+    z <- sinh(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(sinh(x), ptr, exact=FALSE)
+
     z <- cosh(x0)
     ptr <- initializeCpp(z)
     am_i_ok(cosh(x), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -357,6 +357,10 @@ test_that("initialization works correctly with DelayedArray hyperbolic operation
     ptr <- initializeCpp(z)
     am_i_ok(cosh(x), ptr, exact=FALSE)
 
+    z <- tanh(x0)
+    ptr <- initializeCpp(z)
+    am_i_ok(tanh(x), ptr, exact=FALSE)
+
     z <- asinh(x0)
     ptr <- initializeCpp(z)
     am_i_ok(asinh(x), ptr, exact=FALSE)

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -381,6 +381,10 @@ test_that("initialization works correctly with DelayedArray gamma operations", {
     z <- gamma(z0 + 0.1)
     ptr <- initializeCpp(z)
     am_i_ok(gamma(y + 0.1), ptr, exact=FALSE)
+
+    z <- lgamma(z0 + 0.1)
+    ptr <- initializeCpp(z)
+    am_i_ok(lgamma(y + 0.1), ptr, exact=FALSE)
 })
 
 test_that("initialization works correctly with other DelayedArray unary operations", {

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -345,6 +345,10 @@ test_that("initialization works correctly with DelayedArray hyperbolic operation
     z <- acosh(a0 + 2)
     ptr <- initializeCpp(z)
     am_i_ok(acosh(a + 2), ptr, exact=FALSE)
+
+    z <- atanh(a0)
+    ptr <- initializeCpp(z)
+    am_i_ok(atanh(a), ptr, exact=FALSE)
 })
 
 test_that("initialization works correctly with other DelayedArray unary operations", {

--- a/tests/testthat/test-initializeCpp-isometric_unary.R
+++ b/tests/testthat/test-initializeCpp-isometric_unary.R
@@ -310,6 +310,16 @@ test_that("initialization works correctly with DelayedArray nearest integer oper
     am_i_ok(trunc(x), ptr)
 })
 
+test_that("initialization works correctly with DelayedArray trigonometric operations", {
+    set.seed(1000)
+    a <- Matrix::rsparsematrix(1000, 100, 0.1, rand.x = function(n) signif(runif(n, min = -1, max = 1), 2))
+    a0 <- DelayedArray(a)
+
+    z <- acos(a0)
+    ptr <- initializeCpp(z)
+    am_i_ok(acos(a), ptr, exact=FALSE)
+})
+
 test_that("initialization works correctly with other DelayedArray unary operations", {
     z0 <- DelayedArray(y)
 


### PR DESCRIPTION
Add support for 19 unary math functions using 18 functions from C++ standard library plus 1 trial function. The 18 R functions with underling support from the C++ standard library are: `ceiling`, `floor`, `trun`, `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `expm1`, `cos`, `cosh`, `sin`, `sinh`, `tan`, `tanh`, `gamma`, `lgamma`. The one trivial C++ function is the R `sign` function.